### PR TITLE
Use full class name in xml

### DIFF
--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -42,6 +42,8 @@
         <mapstream.version>2.3.5</mapstream.version>
         <map-builder.version>1.0.0</map-builder.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
+        <checkstyle.version>7.8</checkstyle.version>
+        <sevntu.version>1.24.0</sevntu.version>
     </properties>
 
     <dependencies>
@@ -92,6 +94,19 @@
             <version>${map-builder.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.sevntu-checkstyle</groupId>
+            <artifactId>sevntu-checks</artifactId>
+            <version>${sevntu.version}</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleClassNotFoundException.java
+++ b/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleClassNotFoundException.java
@@ -21,49 +21,19 @@
 
 package net.kemitix.checkstyle.ruleset.builder;
 
-import com.google.common.reflect.ClassPath;
-import lombok.Getter;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 /**
- * The origin of the rule.
+ * Raised when a Class to implement a Rule is not found.
  *
- * @author Paul Campbell (pcampbell@kemitix.net)
+ * @author Paul Campbell (pcampbell@kemitix.net).
  */
-public enum RuleSource {
-
-    CHECKSTYLE("com.puppycrawl.tools.checkstyle"),
-    SEVNTU("com.github.sevntu.checkstyle.checks");
-
-    @Getter
-    private final String basePackage;
-
-    private final List<String> checkClasses;
+public class CheckstyleClassNotFoundException extends RuntimeException {
 
     /**
      * Constructor.
      *
-     * @param basePackage the base package that contains all checks from this source
+     * @param name the name of the unimplemented rule
      */
-    RuleSource(final String basePackage) {
-        this.basePackage = basePackage;
-        try {
-            checkClasses = ClassPath.from(getClass().getClassLoader())
-                                    .getTopLevelClassesRecursive(basePackage)
-                                    .stream()
-                                    .map(ClassPath.ClassInfo::getName)
-                                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            throw new CheckstyleSourceLoadException(basePackage, e);
-        }
-    }
-
-    public Stream<String> getCheckClasses() {
-        return checkClasses.stream()
-                           .sorted();
+    public CheckstyleClassNotFoundException(final String name) {
+        super("No class found to implement " + name);
     }
 }

--- a/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleSourceLoadException.java
+++ b/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleSourceLoadException.java
@@ -21,49 +21,22 @@
 
 package net.kemitix.checkstyle.ruleset.builder;
 
-import com.google.common.reflect.ClassPath;
-import lombok.Getter;
-
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
- * The origin of the rule.
+ * Raised when there is an error scanning for check classes.
  *
- * @author Paul Campbell (pcampbell@kemitix.net)
+ * @author Paul Campbell (pcampbell@kemitix.net).
  */
-public enum RuleSource {
-
-    CHECKSTYLE("com.puppycrawl.tools.checkstyle"),
-    SEVNTU("com.github.sevntu.checkstyle.checks");
-
-    @Getter
-    private final String basePackage;
-
-    private final List<String> checkClasses;
+public class CheckstyleSourceLoadException extends RuntimeException {
 
     /**
      * Constructor.
      *
-     * @param basePackage the base package that contains all checks from this source
+     * @param basePackage the base package classes were being loaded from
+     * @param cause       the cause
      */
-    RuleSource(final String basePackage) {
-        this.basePackage = basePackage;
-        try {
-            checkClasses = ClassPath.from(getClass().getClassLoader())
-                                    .getTopLevelClassesRecursive(basePackage)
-                                    .stream()
-                                    .map(ClassPath.ClassInfo::getName)
-                                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            throw new CheckstyleSourceLoadException(basePackage, e);
-        }
-    }
-
-    public Stream<String> getCheckClasses() {
-        return checkClasses.stream()
-                           .sorted();
+    public CheckstyleSourceLoadException(final String basePackage, final IOException cause) {
+        super("Error loading checkstyle rules from package: " + basePackage, cause);
     }
 }

--- a/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleWriter.java
+++ b/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleWriter.java
@@ -101,9 +101,9 @@ class CheckstyleWriter implements CommandLineRunner {
     private String formatRuleAsModule(final Rule rule) {
         if (rule.getProperties()
                 .isEmpty()) {
-            return String.format("<module name=\"%s\"/>", rule.getName());
+            return String.format("<module name=\"%s\"/>", rule.getCanonicalClassName());
         }
-        return String.format("<module name=\"%s\">%n    %s%n</module>", rule.getName(),
+        return String.format("<module name=\"%s\">%n    %s%n</module>", rule.getCanonicalClassName(),
                              formatProperties(rule.getProperties())
                             );
     }

--- a/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/Rule.java
+++ b/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/Rule.java
@@ -41,6 +41,11 @@ public class Rule {
     private static final Locale LOCALE = Locale.ENGLISH;
 
     /**
+     * Configuration properties.
+     */
+    private final Map<String, String> properties = new HashMap<>();
+
+    /**
      * The name of the rule's Check class.
      */
     private String name;
@@ -81,11 +86,6 @@ public class Rule {
     private String reason;
 
     /**
-     * Configuration properties.
-     */
-    private final Map<String, String> properties = new HashMap<>();
-
-    /**
      * Compare two Rules lexicographically for sorting by rule name, ignoring case.
      *
      * @param left  the first rule
@@ -102,6 +102,23 @@ public class Rule {
 
     private String getLowerCaseRuleName() {
         return getName().toLowerCase(LOCALE);
+    }
+
+    /**
+     * Returns the canonical name of the class that implements this rule.
+     *
+     * @return the canonical name of the implementing class
+     */
+    public String getCanonicalClassName() {
+        return source.getCheckClasses()
+                     .filter(this::byRuleName)
+                     .findFirst()
+                     .orElseThrow(() -> new CheckstyleClassNotFoundException(name));
+    }
+
+    private boolean byRuleName(final String classname) {
+        final String classNameWithDelimiter = "." + name;
+        return classname.endsWith(classNameWithDelimiter) || classname.endsWith(classNameWithDelimiter + "Check");
     }
 
 }

--- a/builder/src/test/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleClassNotFoundExceptionTest.java
+++ b/builder/src/test/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleClassNotFoundExceptionTest.java
@@ -1,0 +1,24 @@
+package net.kemitix.checkstyle.ruleset.builder;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CheckstyleClassNotFoundException}.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net).
+ */
+public class CheckstyleClassNotFoundExceptionTest {
+
+    @Test
+    public void canRaiseException() {
+        //given
+        final String classname = "class name";
+        //when
+        final CheckstyleClassNotFoundException exception = new CheckstyleClassNotFoundException(classname);
+        //then
+        assertThat(exception.getMessage()).startsWith("No class found to implement ")
+                                          .endsWith(classname);
+    }
+}

--- a/builder/src/test/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleSourceLoadExceptionTest.java
+++ b/builder/src/test/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleSourceLoadExceptionTest.java
@@ -1,0 +1,28 @@
+package net.kemitix.checkstyle.ruleset.builder;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Tests for {@link CheckstyleSourceLoadException}.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net).
+ */
+public class CheckstyleSourceLoadExceptionTest {
+
+    @Test
+    public void canRaiseException() {
+        //given
+        final String basePackage = "base package";
+        final IOException cause = new IOException();
+        //when
+        final CheckstyleSourceLoadException exception = new CheckstyleSourceLoadException(basePackage, cause);
+        //then
+        assertThat(exception).hasCause(cause)
+                             .hasMessageStartingWith("Error loading checkstyle rules from package: ")
+                             .hasMessageEndingWith(basePackage);
+    }
+}

--- a/builder/src/test/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleWriterTest.java
+++ b/builder/src/test/java/net/kemitix/checkstyle/ruleset/builder/CheckstyleWriterTest.java
@@ -17,7 +17,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,6 +41,8 @@ public class CheckstyleWriterTest {
 
     private String ruleName;
 
+    private String ruleClassname;
+
     private Map<RuleLevel, String> outputFiles;
 
     private Path outputDirectory;
@@ -57,8 +58,8 @@ public class CheckstyleWriterTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        ruleName = UUID.randomUUID()
-                       .toString();
+        ruleName = "RegexpOnFilename";
+        ruleClassname = "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck";
         outputProperties = new OutputProperties();
         outputFiles = new MapBuilder<RuleLevel, String>().put(getOutputFile(RuleLevel.LAYOUT))
                                                          .put(getOutputFile(RuleLevel.NAMING))
@@ -91,7 +92,7 @@ public class CheckstyleWriterTest {
         checkstyleWriter.run();
         //then
         val lines = loadOutputFile(RuleLevel.LAYOUT);
-        assertThat(lines).containsExactly("C:", String.format("TW:<module name=\"%s\"/>", ruleName));
+        assertThat(lines).containsExactly("C:", String.format("TW:<module name=\"%s\"/>", ruleClassname));
     }
 
     // write rule that is below current level
@@ -105,7 +106,7 @@ public class CheckstyleWriterTest {
         checkstyleWriter.run();
         //then
         val lines = loadOutputFile(RuleLevel.NAMING);
-        assertThat(lines).containsExactly("C:", String.format("TW:<module name=\"%s\"/>", ruleName));
+        assertThat(lines).containsExactly("C:", String.format("TW:<module name=\"%s\"/>", ruleClassname));
     }
 
     // write rule with checker parent
@@ -119,7 +120,7 @@ public class CheckstyleWriterTest {
         checkstyleWriter.run();
         //then
         val lines = loadOutputFile(RuleLevel.LAYOUT);
-        assertThat(lines).containsExactly(String.format("C:<module name=\"%s\"/>", ruleName), "TW:");
+        assertThat(lines).containsExactly(String.format("C:<module name=\"%s\"/>", ruleClassname), "TW:");
     }
 
     // write rule with properties
@@ -135,7 +136,7 @@ public class CheckstyleWriterTest {
         checkstyleWriter.run();
         //then
         val lines = loadOutputFile(RuleLevel.LAYOUT);
-        assertThat(lines).containsExactly("C:", String.format("TW:<module name=\"%s\">", ruleName),
+        assertThat(lines).containsExactly("C:", String.format("TW:<module name=\"%s\">", ruleClassname),
                                           "    <property name=\"key\" value=\"value\"/>", "</module>"
                                          );
     }
@@ -207,6 +208,7 @@ public class CheckstyleWriterTest {
     private Rule enabledRule(final RuleLevel level, final RuleParent parent) {
         val rule = new Rule();
         rule.setName(ruleName);
+        rule.setSource(RuleSource.CHECKSTYLE);
         rule.setEnabled(true);
         rule.setLevel(level);
         rule.setParent(parent);

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-1-layout.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-1-layout.xml
@@ -4,62 +4,63 @@
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 
-    <module name="RegexpOnFilename">
+    <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck">
     <property name="fileNamePattern" value="(.sync-conflict-| conflicted copy )"/>
 <property name="match" value="true"/>
 </module>
-<module name="FileTabCharacter"/>
-<module name="Header">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck">
     <property name="fileExtensions" value="java"/>
 <property name="headerFile" value="LICENSE.txt"/>
 </module>
-<module name="NewlineAtEndOfFile">
+<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck">
     <property name="lineSeparator" value="lf"/>
 </module>
 
     <module name="TreeWalker">
 
-        <module name="AnnotationLocation"/>
-<module name="AnnotationUseStyle"/>
-<module name="ArrayTypeStyle"/>
-<module name="AvoidStarImport"/>
-<module name="CommentsIndentation"/>
-<module name="DeclarationOrder"/>
-<module name="EmptyForInitializerPad"/>
-<module name="EmptyForIteratorPad"/>
-<module name="EmptyLineSeparator"/>
-<module name="EmptyStatement"/>
-<module name="GenericWhitespace"/>
-<module name="LeftCurly"/>
-<module name="LineLength">
+        <module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
     <property name="max" value="120"/>
 </module>
-<module name="MethodParamPad"/>
-<module name="NoLineWrap"/>
-<module name="NoWhitespaceAfter">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck">
     <property name="tokens" value="DOT"/>
 <property name="allowLineBreaks" value="false"/>
 </module>
-<module name="NoWhitespaceBefore"/>
-<module name="OneStatementPerLine"/>
-<module name="OperatorWrap"/>
-<module name="OverloadMethodsDeclarationOrder"/>
-<module name="ParenPad"/>
-<module name="RightCurly"/>
-<module name="SeparatorWrap">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck">
     <property name="tokens" value="DOT"/>
 <property name="option" value="nl"/>
 </module>
-<module name="SingleSpaceSeparator"/>
-<module name="TrailingComment"/>
-<module name="TypecastParenPad"/>
-<module name="UnnecessaryParentheses"/>
-<module name="UnusedImports"/>
-<module name="UpperEll"/>
-<module name="WhitespaceAfter"/>
-<module name="WhitespaceAround"/>
-<module name="ForbidCCommentsInMethods"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
 
     </module><!-- /TreeWalker -->
 
 </module><!-- /Checker -->
+

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-2-naming.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-2-naming.xml
@@ -4,94 +4,95 @@
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 
-    <module name="RegexpOnFilename">
+    <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck">
     <property name="fileNamePattern" value="(.sync-conflict-| conflicted copy )"/>
 <property name="match" value="true"/>
 </module>
-<module name="FileTabCharacter"/>
-<module name="Header">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck">
     <property name="fileExtensions" value="java"/>
 <property name="headerFile" value="LICENSE.txt"/>
 </module>
-<module name="NewlineAtEndOfFile">
+<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck">
     <property name="lineSeparator" value="lf"/>
 </module>
-<module name="SuppressWarningsFilter"/>
+<module name="com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter"/>
 
     <module name="TreeWalker">
 
-        <module name="AbbreviationAsWordInName"/>
-<module name="AbstractClassName"/>
-<module name="AnnotationLocation"/>
-<module name="AnnotationUseStyle"/>
-<module name="ArrayTypeStyle"/>
-<module name="AvoidStarImport"/>
-<module name="CatchParameterName"/>
-<module name="ClassTypeParameterName"/>
-<module name="CommentsIndentation"/>
-<module name="ConstantName"/>
-<module name="DeclarationOrder"/>
-<module name="EmptyForInitializerPad"/>
-<module name="EmptyForIteratorPad"/>
-<module name="EmptyLineSeparator"/>
-<module name="EmptyStatement"/>
-<module name="GenericWhitespace"/>
-<module name="InterfaceTypeParameterName"/>
-<module name="LeftCurly"/>
-<module name="LineLength">
+        <module name="com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
     <property name="max" value="120"/>
 </module>
-<module name="LocalFinalVariableName"/>
-<module name="LocalVariableName"/>
-<module name="MagicNumber"/>
-<module name="MemberName"/>
-<module name="MethodName"/>
-<module name="MethodParamPad"/>
-<module name="MethodTypeParameterName"/>
-<module name="ModifierOrder"/>
-<module name="MultipleStringLiterals"/>
-<module name="MultipleVariableDeclarations"/>
-<module name="NeedBraces"/>
-<module name="NoLineWrap"/>
-<module name="NoWhitespaceAfter">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck">
     <property name="tokens" value="DOT"/>
 <property name="allowLineBreaks" value="false"/>
 </module>
-<module name="NoWhitespaceBefore"/>
-<module name="OneStatementPerLine"/>
-<module name="OperatorWrap"/>
-<module name="OverloadMethodsDeclarationOrder"/>
-<module name="PackageName">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck">
     <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]+)*$"/>
 </module>
-<module name="ParameterName"/>
-<module name="ParenPad"/>
-<module name="RightCurly"/>
-<module name="SeparatorWrap">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck">
     <property name="tokens" value="DOT"/>
 <property name="option" value="nl"/>
 </module>
-<module name="SingleSpaceSeparator"/>
-<module name="StaticVariableName"/>
-<module name="SuppressWarnings">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck">
     <property name="format" value="^constantname|covariantequals|equalshashcode|noclone|onetoplevelclass|outertypefilename|packagedeclaration|typename|visibilitymodifier$"/>
 </module>
-<module name="SuppressWarningsHolder"/>
-<module name="TrailingComment"/>
-<module name="TypecastParenPad"/>
-<module name="TypeName"/>
-<module name="UnnecessaryParentheses"/>
-<module name="UnusedImports"/>
-<module name="UpperEll"/>
-<module name="WhitespaceAfter"/>
-<module name="WhitespaceAround"/>
-<module name="EnumValueName"/>
-<module name="ForbidCCommentsInMethods"/>
-<module name="NameConventionForJunit4TestClasses"/>
-<module name="NumericLiteralNeedsUnderscore"/>
-<module name="SimpleAccessorNameNotation"/>
-<module name="UniformEnumConstantName"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscoreCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotationCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck"/>
 
     </module><!-- /TreeWalker -->
 
 </module><!-- /Checker -->
+

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-3-javadoc.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-3-javadoc.xml
@@ -4,120 +4,121 @@
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 
-    <module name="RegexpOnFilename">
+    <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck">
     <property name="fileNamePattern" value="(.sync-conflict-| conflicted copy )"/>
 <property name="match" value="true"/>
 </module>
-<module name="FileTabCharacter"/>
-<module name="Header">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck">
     <property name="fileExtensions" value="java"/>
 <property name="headerFile" value="LICENSE.txt"/>
 </module>
-<module name="JavadocPackage"/>
-<module name="NewlineAtEndOfFile">
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck">
     <property name="lineSeparator" value="lf"/>
 </module>
-<module name="SuppressWarningsFilter"/>
-<module name="Translation"/>
-<module name="UniqueProperties"/>
+<module name="com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck"/>
 
     <module name="TreeWalker">
 
-        <module name="AbbreviationAsWordInName"/>
-<module name="AbstractClassName"/>
-<module name="AnnotationLocation"/>
-<module name="AnnotationUseStyle"/>
-<module name="ArrayTypeStyle"/>
-<module name="AtclauseOrder">
+        <module name="com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck">
     <property name="tagOrder" value="@param, @author, @version, @serial, @return, @throws, @exception,             @serialData, @serialField, @see, @since, @deprecated"/>
 </module>
-<module name="AvoidStarImport"/>
-<module name="CatchParameterName"/>
-<module name="ClassTypeParameterName"/>
-<module name="CommentsIndentation"/>
-<module name="ConstantName"/>
-<module name="DeclarationOrder"/>
-<module name="EmptyForInitializerPad"/>
-<module name="EmptyForIteratorPad"/>
-<module name="EmptyLineSeparator"/>
-<module name="EmptyStatement"/>
-<module name="FallThrough"/>
-<module name="GenericWhitespace"/>
-<module name="InterfaceTypeParameterName"/>
-<module name="JavadocMethod">
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck">
     <property name="allowMissingPropertyJavadoc" value="true"/>
 <property name="validateThrows" value="true"/>
 <property name="scope" value="package"/>
 </module>
-<module name="JavadocParagraph"/>
-<module name="JavadocStyle"/>
-<module name="JavadocType">
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck">
     <property name="authorFormat" value="^.+ (\S+@[\S.]+)$"/>
 </module>
-<module name="LeftCurly"/>
-<module name="LineLength">
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
     <property name="max" value="120"/>
 </module>
-<module name="LocalFinalVariableName"/>
-<module name="LocalVariableName"/>
-<module name="MagicNumber"/>
-<module name="MemberName"/>
-<module name="MethodName"/>
-<module name="MethodParamPad"/>
-<module name="MethodTypeParameterName"/>
-<module name="MissingDeprecated"/>
-<module name="ModifierOrder"/>
-<module name="MultipleStringLiterals"/>
-<module name="MultipleVariableDeclarations"/>
-<module name="NeedBraces"/>
-<module name="NoLineWrap"/>
-<module name="NonEmptyAtclauseDescription"/>
-<module name="NoWhitespaceAfter">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck">
     <property name="tokens" value="DOT"/>
 <property name="allowLineBreaks" value="false"/>
 </module>
-<module name="NoWhitespaceBefore"/>
-<module name="OneStatementPerLine"/>
-<module name="OperatorWrap"/>
-<module name="OverloadMethodsDeclarationOrder"/>
-<module name="PackageDeclaration"/>
-<module name="PackageName">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck">
     <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]+)*$"/>
 </module>
-<module name="ParameterName"/>
-<module name="ParenPad"/>
-<module name="RightCurly"/>
-<module name="SeparatorWrap">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck">
     <property name="tokens" value="DOT"/>
 <property name="option" value="nl"/>
 </module>
-<module name="SingleSpaceSeparator"/>
-<module name="StaticVariableName"/>
-<module name="SuppressWarnings">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck">
     <property name="format" value="^constantname|covariantequals|equalshashcode|noclone|onetoplevelclass|outertypefilename|packagedeclaration|typename|visibilitymodifier$"/>
 </module>
-<module name="SuppressWarningsHolder"/>
-<module name="TodoComment">
+<module name="com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck">
     <property name="format" value="^(\s*\*).*((TODO)|(FIXME))"/>
 </module>
-<module name="TrailingComment"/>
-<module name="TypecastParenPad"/>
-<module name="TypeName"/>
-<module name="UncommentedMain">
+<module name="com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck">
     <property name="excludedClasses" value="(Main|Application)$"/>
 </module>
-<module name="UnnecessaryParentheses"/>
-<module name="UnusedImports"/>
-<module name="UpperEll"/>
-<module name="WhitespaceAfter"/>
-<module name="WhitespaceAround"/>
-<module name="EnumValueName"/>
-<module name="ForbidCCommentsInMethods"/>
-<module name="NameConventionForJunit4TestClasses"/>
-<module name="NumericLiteralNeedsUnderscore"/>
-<module name="SimpleAccessorNameNotation"/>
-<module name="UniformEnumConstantName"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscoreCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotationCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck"/>
 
     </module><!-- /TreeWalker -->
 
 </module><!-- /Checker -->
+

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
@@ -4,179 +4,180 @@
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 
-    <module name="RegexpOnFilename">
+    <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck">
     <property name="fileNamePattern" value="(.sync-conflict-| conflicted copy )"/>
 <property name="match" value="true"/>
 </module>
-<module name="FileTabCharacter"/>
-<module name="Header">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck">
     <property name="fileExtensions" value="java"/>
 <property name="headerFile" value="LICENSE.txt"/>
 </module>
-<module name="JavadocPackage"/>
-<module name="NewlineAtEndOfFile">
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck">
     <property name="lineSeparator" value="lf"/>
 </module>
-<module name="SuppressWarningsFilter"/>
-<module name="Translation"/>
-<module name="UniqueProperties"/>
+<module name="com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck"/>
 
     <module name="TreeWalker">
 
-        <module name="AbbreviationAsWordInName"/>
-<module name="AbstractClassName"/>
-<module name="AnnotationLocation"/>
-<module name="AnnotationUseStyle"/>
-<module name="ArrayTypeStyle"/>
-<module name="AtclauseOrder">
+        <module name="com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck">
     <property name="tagOrder" value="@param, @author, @version, @serial, @return, @throws, @exception,             @serialData, @serialField, @see, @since, @deprecated"/>
 </module>
-<module name="AvoidEscapedUnicodeCharacters">
+<module name="com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck">
     <property name="allowEscapesForControlCharacters" value="true"/>
 </module>
-<module name="AvoidStarImport"/>
-<module name="CatchParameterName"/>
-<module name="ClassTypeParameterName"/>
-<module name="CommentsIndentation"/>
-<module name="ConstantName"/>
-<module name="DeclarationOrder"/>
-<module name="DefaultComesLast"/>
-<module name="EmptyBlock"/>
-<module name="EmptyCatchBlock">
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck">
     <property name="commentFormat" value="expected|ignore"/>
 </module>
-<module name="EmptyForInitializerPad"/>
-<module name="EmptyForIteratorPad"/>
-<module name="EmptyLineSeparator"/>
-<module name="EmptyStatement"/>
-<module name="EqualsAvoidNull"/>
-<module name="ExplicitInitialization"/>
-<module name="FallThrough"/>
-<module name="FinalParameters"/>
-<module name="GenericWhitespace"/>
-<module name="HiddenField">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck">
     <property name="ignoreConstructorParameter" value="true"/>
 <property name="ignoreSetter" value="true"/>
 </module>
-<module name="HideUtilityClassConstructor"/>
-<module name="IllegalCatch"/>
-<module name="IllegalImport"/>
-<module name="IllegalThrows"/>
-<module name="IllegalToken"/>
-<module name="IllegalType">
+<module name="com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck">
     <property name="illegalClassNames" value="java.util.ArrayDeque, java.util.ArrayList, java.util.EnumMap, java.util.EnumSet, java.util.HashMap, java.util.HashSet, java.util.IdentityHashMap, java.util.LinkedHashMap, java.util.LinkedHashSet, java.util.LinkedList, java.util.PriorityQueue, java.util.TreeMap, java.util.TreeSet"/>
 </module>
-<module name="InnerAssignment"/>
-<module name="InnerTypeLast"/>
-<module name="InterfaceTypeParameterName"/>
-<module name="JavadocMethod">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck">
     <property name="allowMissingPropertyJavadoc" value="true"/>
 <property name="validateThrows" value="true"/>
 <property name="scope" value="package"/>
 </module>
-<module name="JavadocParagraph"/>
-<module name="JavadocStyle"/>
-<module name="JavadocType">
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck">
     <property name="authorFormat" value="^.+ (\S+@[\S.]+)$"/>
 </module>
-<module name="LeftCurly"/>
-<module name="LineLength">
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
     <property name="max" value="120"/>
 </module>
-<module name="LocalFinalVariableName"/>
-<module name="LocalVariableName"/>
-<module name="MagicNumber"/>
-<module name="MemberName"/>
-<module name="MethodName"/>
-<module name="MethodParamPad"/>
-<module name="MethodTypeParameterName"/>
-<module name="MissingDeprecated"/>
-<module name="MissingSwitchDefault"/>
-<module name="ModifiedControlVariable">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck">
     <property name="skipEnhancedForLoopVariable" value="true"/>
 </module>
-<module name="ModifierOrder"/>
-<module name="MultipleStringLiterals"/>
-<module name="MultipleVariableDeclarations"/>
-<module name="MutableException"/>
-<module name="NeedBraces"/>
-<module name="NoClone"/>
-<module name="NoFinalizer"/>
-<module name="NoLineWrap"/>
-<module name="NonEmptyAtclauseDescription"/>
-<module name="NoWhitespaceAfter">
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.MutableExceptionCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck">
     <property name="tokens" value="DOT"/>
 <property name="allowLineBreaks" value="false"/>
 </module>
-<module name="NoWhitespaceBefore"/>
-<module name="OneStatementPerLine"/>
-<module name="OneTopLevelClass"/>
-<module name="OperatorWrap"/>
-<module name="OuterTypeFilename"/>
-<module name="OverloadMethodsDeclarationOrder"/>
-<module name="PackageAnnotation"/>
-<module name="PackageDeclaration"/>
-<module name="PackageName">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck">
     <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]+)*$"/>
 </module>
-<module name="ParameterName"/>
-<module name="ParenPad"/>
-<module name="RedundantModifier"/>
-<module name="RequireThis">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck">
     <property name="checkMethods" value="false"/>
 </module>
-<module name="RightCurly"/>
-<module name="SeparatorWrap">
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck">
     <property name="tokens" value="DOT"/>
 <property name="option" value="nl"/>
 </module>
-<module name="SingleSpaceSeparator"/>
-<module name="StaticVariableName"/>
-<module name="StringLiteralEquality"/>
-<module name="SuppressWarnings">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck">
     <property name="format" value="^constantname|covariantequals|equalshashcode|noclone|onetoplevelclass|outertypefilename|packagedeclaration|typename|visibilitymodifier$"/>
 </module>
-<module name="SuppressWarningsHolder"/>
-<module name="TodoComment">
+<module name="com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck">
     <property name="format" value="^(\s*\*).*((TODO)|(FIXME))"/>
 </module>
-<module name="TrailingComment"/>
-<module name="TypecastParenPad"/>
-<module name="TypeName"/>
-<module name="UncommentedMain">
+<module name="com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck">
     <property name="excludedClasses" value="(Main|Application)$"/>
 </module>
-<module name="UnnecessaryParentheses"/>
-<module name="UnusedImports"/>
-<module name="UpperEll"/>
-<module name="VariableDeclarationUsageDistance"/>
-<module name="VisibilityModifier"/>
-<module name="WhitespaceAfter"/>
-<module name="WhitespaceAround"/>
-<module name="AvoidConstantAsFirstOperandInCondition"/>
-<module name="AvoidHidingCauseException"/>
-<module name="AvoidNotShortCircuitOperatorsForBoolean"/>
-<module name="DiamondOperatorForVariableDefinition"/>
-<module name="EitherLogOrThrow"/>
-<module name="EnumValueName"/>
-<module name="ForbidCCommentsInMethods"/>
-<module name="LogicConditionNeedOptimization"/>
-<module name="NameConventionForJunit4TestClasses"/>
-<module name="NoMainMethodInAbstractClass"/>
-<module name="NumericLiteralNeedsUnderscore"/>
-<module name="OverridableMethodInConstructor"/>
-<module name="PublicReferenceToPrivateType"/>
-<module name="RedundantReturn"/>
-<module name="ReturnBooleanFromTernary"/>
-<module name="ReturnNullInsteadOfBoolean"/>
-<module name="SimpleAccessorNameNotation"/>
-<module name="SingleBreakOrContinue"/>
-<module name="TernaryPerExpressionCount"/>
-<module name="UniformEnumConstantName"/>
-<module name="UselessSingleCatch"/>
-<module name="UselessSuperCtorCall"/>
-<module name="MoveVariableInsideIfCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.AvoidConstantAsFirstOperandInConditionCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.AvoidHidingCauseExceptionCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.AvoidNotShortCircuitOperatorsForBooleanCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.DiamondOperatorForVariableDefinitionCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.EitherLogOrThrowCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.LogicConditionNeedOptimizationCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.design.NoMainMethodInAbstractClassCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscoreCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.OverridableMethodInConstructorCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.design.PublicReferenceToPrivateTypeCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.RedundantReturnCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ReturnBooleanFromTernaryCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ReturnNullInsteadOfBooleanCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotationCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.SingleBreakOrContinueCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.TernaryPerExpressionCountCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.UselessSingleCatchCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.UselessSuperCtorCallCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.MoveVariableInsideIfCheck"/>
 
     </module><!-- /TreeWalker -->
 
 </module><!-- /Checker -->
+

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
@@ -4,232 +4,233 @@
         "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 
-    <module name="RegexpOnFilename">
+    <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck">
     <property name="fileNamePattern" value="(.sync-conflict-| conflicted copy )"/>
 <property name="match" value="true"/>
 </module>
-<module name="FileLength"/>
-<module name="FileTabCharacter"/>
-<module name="Header">
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck">
     <property name="fileExtensions" value="java"/>
 <property name="headerFile" value="LICENSE.txt"/>
 </module>
-<module name="JavadocPackage"/>
-<module name="NewlineAtEndOfFile">
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck">
     <property name="lineSeparator" value="lf"/>
 </module>
-<module name="SuppressWarningsFilter"/>
-<module name="Translation"/>
-<module name="UniqueProperties"/>
+<module name="com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck"/>
 
     <module name="TreeWalker">
 
-        <module name="AbbreviationAsWordInName"/>
-<module name="AbstractClassName"/>
-<module name="AnnotationLocation"/>
-<module name="AnnotationUseStyle"/>
-<module name="AnonInnerLength"/>
-<module name="ArrayTypeStyle"/>
-<module name="AtclauseOrder">
+        <module name="com.puppycrawl.tools.checkstyle.checks.naming.AbbreviationAsWordInNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.AnonInnerLengthCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck">
     <property name="tagOrder" value="@param, @author, @version, @serial, @return, @throws, @exception,             @serialData, @serialField, @see, @since, @deprecated"/>
 </module>
-<module name="AvoidEscapedUnicodeCharacters">
+<module name="com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck">
     <property name="allowEscapesForControlCharacters" value="true"/>
 </module>
-<module name="AvoidInlineConditionals"/>
-<module name="AvoidNestedBlocks"/>
-<module name="AvoidStarImport"/>
-<module name="AvoidStaticImport">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck">
     <property name="excludes" value="org.assertj.core.api.Assertions.assertThat,org.mockito.BDDMockito.given,org.mockito.Mockito.*,org.mockito.Matchers.*,org.mockito.Mockito.*"/>
 </module>
-<module name="BooleanExpressionComplexity">
+<module name="com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck">
     <property name="max" value="2"/>
 </module>
-<module name="CatchParameterName"/>
-<module name="ClassDataAbstractionCoupling"/>
-<module name="ClassFanOutComplexity"/>
-<module name="ClassTypeParameterName"/>
-<module name="CommentsIndentation"/>
-<module name="ConstantName"/>
-<module name="CovariantEquals"/>
-<module name="CyclomaticComplexity">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ClassTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck">
     <property name="max" value="5"/>
 </module>
-<module name="DeclarationOrder"/>
-<module name="DefaultComesLast"/>
-<module name="DesignForExtension"/>
-<module name="EmptyBlock"/>
-<module name="EmptyCatchBlock">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck">
     <property name="commentFormat" value="expected|ignore"/>
 </module>
-<module name="EmptyForInitializerPad"/>
-<module name="EmptyForIteratorPad"/>
-<module name="EmptyLineSeparator"/>
-<module name="EmptyStatement"/>
-<module name="EqualsAvoidNull"/>
-<module name="EqualsHashCode"/>
-<module name="ExecutableStatementCount"/>
-<module name="ExplicitInitialization"/>
-<module name="FallThrough"/>
-<module name="FinalClass"/>
-<module name="FinalParameters"/>
-<module name="GenericWhitespace"/>
-<module name="HiddenField">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck">
     <property name="ignoreConstructorParameter" value="true"/>
 <property name="ignoreSetter" value="true"/>
 </module>
-<module name="HideUtilityClassConstructor"/>
-<module name="IllegalCatch"/>
-<module name="IllegalImport"/>
-<module name="IllegalThrows"/>
-<module name="IllegalToken"/>
-<module name="IllegalType">
+<module name="com.puppycrawl.tools.checkstyle.checks.design.HideUtilityClassConstructorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck">
     <property name="illegalClassNames" value="java.util.ArrayDeque, java.util.ArrayList, java.util.EnumMap, java.util.EnumSet, java.util.HashMap, java.util.HashSet, java.util.IdentityHashMap, java.util.LinkedHashMap, java.util.LinkedHashSet, java.util.LinkedList, java.util.PriorityQueue, java.util.TreeMap, java.util.TreeSet"/>
 </module>
-<module name="InnerAssignment"/>
-<module name="InnerTypeLast"/>
-<module name="InterfaceIsType"/>
-<module name="InterfaceTypeParameterName"/>
-<module name="JavadocMethod">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.InterfaceIsTypeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck">
     <property name="allowMissingPropertyJavadoc" value="true"/>
 <property name="validateThrows" value="true"/>
 <property name="scope" value="package"/>
 </module>
-<module name="JavadocParagraph"/>
-<module name="JavadocStyle"/>
-<module name="JavadocType">
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck">
     <property name="authorFormat" value="^.+ (\S+@[\S.]+)$"/>
 </module>
-<module name="JavaNCSS">
+<module name="com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck">
     <property name="classMaximum" value="1200"/>
 <property name="fileMaximum" value="1600"/>
 <property name="methodMaximum" value="40"/>
 </module>
-<module name="LeftCurly"/>
-<module name="LineLength">
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
     <property name="max" value="120"/>
 </module>
-<module name="LocalFinalVariableName"/>
-<module name="LocalVariableName"/>
-<module name="MagicNumber"/>
-<module name="MemberName"/>
-<module name="MethodCount">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.MethodCountCheck">
     <property name="maxTotal" value="30"/>
 </module>
-<module name="MethodLength">
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck">
     <property name="max" value="40"/>
 </module>
-<module name="MethodName"/>
-<module name="MethodParamPad"/>
-<module name="MethodTypeParameterName"/>
-<module name="MissingDeprecated"/>
-<module name="MissingSwitchDefault"/>
-<module name="ModifiedControlVariable">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.MethodTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck">
     <property name="skipEnhancedForLoopVariable" value="true"/>
 </module>
-<module name="ModifierOrder"/>
-<module name="MultipleStringLiterals"/>
-<module name="MultipleVariableDeclarations"/>
-<module name="MutableException"/>
-<module name="NeedBraces"/>
-<module name="NestedForDepth"/>
-<module name="NestedIfDepth"/>
-<module name="NestedTryDepth">
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.MutableExceptionCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck">
     <property name="max" value="0"/>
 </module>
-<module name="NoClone"/>
-<module name="NoFinalizer"/>
-<module name="NoLineWrap"/>
-<module name="NonEmptyAtclauseDescription"/>
-<module name="NoWhitespaceAfter">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceAfterCheck">
     <property name="tokens" value="DOT"/>
 <property name="allowLineBreaks" value="false"/>
 </module>
-<module name="NoWhitespaceBefore"/>
-<module name="NPathComplexity">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck">
     <property name="max" value="5"/>
 </module>
-<module name="OneStatementPerLine"/>
-<module name="OneTopLevelClass"/>
-<module name="OperatorWrap"/>
-<module name="OuterTypeFilename"/>
-<module name="OverloadMethodsDeclarationOrder"/>
-<module name="PackageAnnotation"/>
-<module name="PackageDeclaration"/>
-<module name="PackageName">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.PackageNameCheck">
     <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]+)*$"/>
 </module>
-<module name="ParameterName"/>
-<module name="ParameterNumber">
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck">
     <property name="ignoreOverriddenMethods" value="true"/>
 </module>
-<module name="ParenPad"/>
-<module name="RedundantModifier"/>
-<module name="RequireThis">
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck">
     <property name="checkMethods" value="false"/>
 </module>
-<module name="ReturnCount"/>
-<module name="RightCurly"/>
-<module name="SeparatorWrap">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck">
     <property name="tokens" value="DOT"/>
 <property name="option" value="nl"/>
 </module>
-<module name="SimplifyBooleanExpression"/>
-<module name="SimplifyBooleanReturn"/>
-<module name="SingleSpaceSeparator"/>
-<module name="StaticVariableName"/>
-<module name="StringLiteralEquality"/>
-<module name="SuppressWarnings">
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.StaticVariableNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck">
     <property name="format" value="^constantname|covariantequals|equalshashcode|noclone|onetoplevelclass|outertypefilename|packagedeclaration|typename|visibilitymodifier$"/>
 </module>
-<module name="SuppressWarningsHolder"/>
-<module name="ThrowsCount"/>
-<module name="TodoComment">
+<module name="com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.ThrowsCountCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck">
     <property name="format" value="^(\s*\*).*((TODO)|(FIXME))"/>
 </module>
-<module name="TrailingComment"/>
-<module name="TypecastParenPad"/>
-<module name="TypeName"/>
-<module name="UncommentedMain">
+<module name="com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck">
     <property name="excludedClasses" value="(Main|Application)$"/>
 </module>
-<module name="UnnecessaryParentheses"/>
-<module name="UnusedImports"/>
-<module name="UpperEll"/>
-<module name="VariableDeclarationUsageDistance"/>
-<module name="VisibilityModifier"/>
-<module name="WhitespaceAfter"/>
-<module name="WhitespaceAround"/>
-<module name="AvoidConstantAsFirstOperandInCondition"/>
-<module name="AvoidHidingCauseException"/>
-<module name="AvoidNotShortCircuitOperatorsForBoolean"/>
-<module name="ConfusingCondition"/>
-<module name="ConstructorWithoutParams"/>
-<module name="DiamondOperatorForVariableDefinition"/>
-<module name="EitherLogOrThrow"/>
-<module name="EnumValueName"/>
-<module name="ForbidCCommentsInMethods"/>
-<module name="ForbidReturnInFinallyBlock"/>
-<module name="ForbidWildcardAsReturnType"/>
-<module name="LogicConditionNeedOptimization"/>
-<module name="MapIterationInForEachLoop"/>
-<module name="NameConventionForJunit4TestClasses"/>
-<module name="NestedSwitch"/>
-<module name="NoMainMethodInAbstractClass"/>
-<module name="NumericLiteralNeedsUnderscore"/>
-<module name="OverridableMethodInConstructor"/>
-<module name="PublicReferenceToPrivateType"/>
-<module name="RedundantReturn"/>
-<module name="ReturnBooleanFromTernary"/>
-<module name="ReturnNullInsteadOfBoolean"/>
-<module name="SimpleAccessorNameNotation"/>
-<module name="SingleBreakOrContinue"/>
-<module name="TernaryPerExpressionCount"/>
-<module name="UniformEnumConstantName"/>
-<module name="UselessSingleCatch"/>
-<module name="UselessSuperCtorCall"/>
-<module name="MoveVariableInsideIfCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.UpperEllCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAfterCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.AvoidConstantAsFirstOperandInConditionCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.AvoidHidingCauseExceptionCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.AvoidNotShortCircuitOperatorsForBooleanCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ConfusingConditionCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.design.ConstructorWithoutParamsCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.DiamondOperatorForVariableDefinitionCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.EitherLogOrThrowCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ForbidReturnInFinallyBlockCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.design.ForbidWildcardAsReturnTypeCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.LogicConditionNeedOptimizationCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.MapIterationInForEachLoopCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.design.NestedSwitchCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.design.NoMainMethodInAbstractClassCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscoreCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.OverridableMethodInConstructorCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.design.PublicReferenceToPrivateTypeCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.RedundantReturnCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ReturnBooleanFromTernaryCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.ReturnNullInsteadOfBooleanCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotationCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.SingleBreakOrContinueCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.TernaryPerExpressionCountCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.UselessSingleCatchCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.UselessSuperCtorCallCheck"/>
+<module name="com.github.sevntu.checkstyle.checks.coding.MoveVariableInsideIfCheck"/>
 
     </module><!-- /TreeWalker -->
 
 </module><!-- /Checker -->
+

--- a/travis-ci/travis-deploy.sh
+++ b/travis-ci/travis-deploy.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
 if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+	echo "Preparing to deploy to nexus..."
 	openssl aes-256-cbc -K $encrypted_efec3258f55d_key -iv $encrypted_efec3258f55d_iv \
 		-in travis-ci/codesigning.asc.enc -out travis-ci/codesigning.asc -d
+	echo "Signing key decrypted"
 	gpg --batch --fast-import travis-ci/codesigning.asc
+	echo "Signing key imported"
 	./mvnw --projects plugin,ruleset --settings travis-ci/travis-settings.xml \
 		-Dskip-Tests=true -P release -B deploy
+	echo "Deploy complete"
+else
+	echo "Not deploying"
+	echo "  TRAVIS_BRANCH: $TRAVIS_BRANCH"
+	echo "  TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"
 fi
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,6 @@
+box: maven:3.5.0-jdk-8
+
+build:
+  steps:
+  - xenoterracide/maven:
+    goals: clean install


### PR DESCRIPTION
In Checkstyle 7.8 a new mechanisim is used to lookup rules by
name. This new method causes an exception to be thrown is there are
more than one classes found that match the rule name.

The solution is to use fully qualified class names in the module tag
in the XML ruleset files.