### PR TITLE
Relax fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ CHANGELOG
 * EmptyLineSeparator: disabled
 * Upgrade `tiles-maven-plugin` to 2.11
 * Upgrade `checkstyle` to 8.9
+* Upgrade `sevntu-checkstyle` to 1.29.0
 
 4.1.0
 -----

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * EmptyLineSeparator: disabled
+* Upgrade `tiles-maven-plugin` to 2.11
 
 4.1.0
 -----

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ CHANGELOG
 
 * EmptyLineSeparator: disabled
 * Upgrade `tiles-maven-plugin` to 2.11
+* Upgrade `checkstyle` to 8.9
 
 4.1.0
 -----

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.2.0
+-----
+
+* EmptyLineSeparator: disabled
+
 4.1.0
 -----
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ CHANGELOG
 
 * EmptyLineSeparator: disabled
 * Upgrade `tiles-maven-plugin` to 2.11
-* Upgrade `checkstyle` to 8.9
+* Upgrade `checkstyle` to 8.10
 * Upgrade `sevntu-checkstyle` to 1.29.0
 
 4.1.0

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Rule|Level|Source|Enabled|Suppressible
 [EmptyCatchBlock](#emptycatchblock)|tweaks|checkstyle|Yes|
 [EmptyForInitializerPad](#emptyforinitializerpad)|layout|checkstyle|Yes|
 [EmptyForIteratorPad](#emptyforiteratorpad)|layout|checkstyle|Yes|
-[EmptyLineSeparator](#emptylineseparator)|layout|checkstyle|Yes|
+[EmptyLineSeparator](#emptylineseparator)|layout|checkstyle||
 [EmptyPublicCtorInClass](#emptypublicctorinclass)|tweaks|sevntu|Yes|
 [EmptyStatement](#emptystatement)|layout|checkstyle|Yes|
 [EnumValueName](#enumvaluename)|naming|sevntu|Yes|
@@ -767,59 +767,6 @@ for (Iterator i = list.getIterator(); i.hasNext() ;) {}
 Invalid:
 ````
 for (Iterator i = list.getIterator(); i.hasNext() ; ) {}
-````
-#### [EmptyLineSeparator](http://checkstyle.sourceforge.net/config_whitespace.html#EmptyLineSeparator)
-
-Checks that there are blank lines between header, package, import blocks, field, constructors, methods, nested classes, static initialisers and instance initialisers.
-
-Valid:
-````
-/**
- * Licence header.
- */
-
-package net.kemitix.foo;
-
-import ...;
-import ...;
-
-class Foo {
-
-    private int a;
-
-    private int b;
-
-    Foo() {}
-
-    Foo(int a, int b) {}
-
-    int getA() {}
-
-    int getB() {}
-
-    class Bar {
-    }
-}
-````
-
-Invalid:
-````
-/**
- * Licence header.
- */
-package net.kemitix.foo;
-import ...;
-import ...;
-class Foo {
-    private int a;
-    private int b;
-    Foo() {}
-    Foo(int a, int b) {}
-    int getA() {}
-    int getB() {}
-    class Bar {
-    }
-}
 ````
 #### [EmptyStatement](http://checkstyle.sourceforge.net/config_coding.html#EmptyStatement)
 
@@ -2643,6 +2590,9 @@ Ref: Clean Code, Robert C. Martin, J1: Avoid Long Import Lists by Using Wildcard
 
 Ref: Clean Code, Robert C. Martin, J2: Don't Inherit Constants
 Recommends using a static import to access constants from another class over inheriting them.
+#### [EmptyLineSeparator](http://checkstyle.sourceforge.net/config_whitespace.html#EmptyLineSeparator)
+
+
 #### [FinalLocalVariable](http://checkstyle.sourceforge.net/config_coding.html#FinalLocalVariable)
 
 Doesn't recognise Lombok's `val` as being `final`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The simplest way to use the ruleset is with the maven-tile:
 ```xml
 <project>
     <properties>
-        <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
+        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
     </properties>
     <build>
         <plugins>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -23,7 +23,7 @@
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
         <checkstyle.version>8.9</checkstyle.version>
-        <sevntu.version>1.27.0</sevntu.version>
+        <sevntu.version>1.29.0</sevntu.version>
         <lombok.version>1.16.20</lombok.version>
         <spring-platform.version>Brussels-SR6</spring-platform.version>
         <spring-boot.version>1.5.9.RELEASE</spring-boot.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -22,7 +22,7 @@
         <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
-        <checkstyle.version>8.9</checkstyle.version>
+        <checkstyle.version>8.10</checkstyle.version>
         <sevntu.version>1.29.0</sevntu.version>
         <lombok.version>1.16.20</lombok.version>
         <spring-platform.version>Brussels-SR6</spring-platform.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -22,7 +22,7 @@
         <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
-        <checkstyle.version>8.7</checkstyle.version>
+        <checkstyle.version>8.9</checkstyle.version>
         <sevntu.version>1.27.0</sevntu.version>
         <lombok.version>1.16.20</lombok.version>
         <spring-platform.version>Brussels-SR6</spring-platform.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <maven.install.skip>true</maven.install.skip>
         <java.version>1.8</java.version>
-        <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
+        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
         <checkstyle.version>8.7</checkstyle.version>

--- a/builder/src/main/resources/README-template.md
+++ b/builder/src/main/resources/README-template.md
@@ -20,7 +20,7 @@ The simplest way to use the ruleset is with the maven-tile:
 ```xml
 <project>
     <properties>
-        <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
+        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
     </properties>
     <build>
         <plugins>

--- a/builder/src/main/resources/application.yml
+++ b/builder/src/main/resources/application.yml
@@ -241,9 +241,10 @@ rules:
         name: EmptyLineSeparator
         parent: TREEWALKER
         level: LAYOUT
-        enabled: true
+        enabled: false
         source: CHECKSTYLE
         uri: http://checkstyle.sourceforge.net/config_whitespace.html#EmptyLineSeparator
+        reason:
     -
         name: EmptyStatement
         parent: TREEWALKER

--- a/regressions/pom.xml
+++ b/regressions/pom.xml
@@ -21,7 +21,7 @@
 
         <java.version>1.8</java.version>
         <checkstyle.version>8.9</checkstyle.version>
-        <sevntu.version>1.27.0</sevntu.version>
+        <sevntu.version>1.29.0</sevntu.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <kemitix.checkstyle.ruleset.version>${project.version}</kemitix.checkstyle.ruleset.version>
         <!--<kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>-->

--- a/regressions/pom.xml
+++ b/regressions/pom.xml
@@ -20,7 +20,7 @@
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
         <java.version>1.8</java.version>
-        <checkstyle.version>8.9</checkstyle.version>
+        <checkstyle.version>8.10</checkstyle.version>
         <sevntu.version>1.29.0</sevntu.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <kemitix.checkstyle.ruleset.version>${project.version}</kemitix.checkstyle.ruleset.version>

--- a/regressions/pom.xml
+++ b/regressions/pom.xml
@@ -20,7 +20,7 @@
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
         <java.version>1.8</java.version>
-        <checkstyle.version>8.7</checkstyle.version>
+        <checkstyle.version>8.9</checkstyle.version>
         <sevntu.version>1.27.0</sevntu.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <kemitix.checkstyle.ruleset.version>${project.version}</kemitix.checkstyle.ruleset.version>

--- a/regressions/pom.xml
+++ b/regressions/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
-        <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
+        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
         <java.version>1.8</java.version>

--- a/ruleset/pom.xml
+++ b/ruleset/pom.xml
@@ -21,7 +21,7 @@
     <url>https://github.com/kemitix/kemitix-checkstyle-ruleset</url>
 
     <properties>
-        <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
+        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
         <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
     </properties>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-1-layout.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-1-layout.xml
@@ -26,7 +26,6 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-2-naming.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-2-naming.xml
@@ -32,7 +32,6 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-3-javadoc.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-3-javadoc.xml
@@ -38,7 +38,6 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
@@ -46,7 +46,6 @@
 </module>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck">

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
@@ -62,7 +62,6 @@
 </module>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck"/>

--- a/tile/pom.xml
+++ b/tile/pom.xml
@@ -17,7 +17,7 @@
     <packaging>tile</packaging>
 
     <properties>
-        <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
+        <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
     </properties>
 

--- a/tile/tile.xml
+++ b/tile/tile.xml
@@ -1,7 +1,7 @@
 <project>
     <properties>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <checkstyle.version>8.9</checkstyle.version>
+        <checkstyle.version>8.10</checkstyle.version>
         <sevntu.version>1.29.0</sevntu.version>
         <kemitix.checkstyle.ruleset.version>4.0.1</kemitix.checkstyle.ruleset.version>
         <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>

--- a/tile/tile.xml
+++ b/tile/tile.xml
@@ -2,7 +2,7 @@
     <properties>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <checkstyle.version>8.9</checkstyle.version>
-        <sevntu.version>1.27.0</sevntu.version>
+        <sevntu.version>1.29.0</sevntu.version>
         <kemitix.checkstyle.ruleset.version>4.0.1</kemitix.checkstyle.ruleset.version>
         <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>
         <kemitix.checkstyle.ruleset.location>net/kemitix/checkstyle-${kemitix.checkstyle.ruleset.level}.xml</kemitix.checkstyle.ruleset.location>

--- a/tile/tile.xml
+++ b/tile/tile.xml
@@ -1,7 +1,7 @@
 <project>
     <properties>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <checkstyle.version>8.7</checkstyle.version>
+        <checkstyle.version>8.9</checkstyle.version>
         <sevntu.version>1.27.0</sevntu.version>
         <kemitix.checkstyle.ruleset.version>4.0.1</kemitix.checkstyle.ruleset.version>
         <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>


### PR DESCRIPTION
* `EmptyLineSeparator`: disabled
* Upgrade `tiles-maven-plugin` to 2.11
* Upgrade `checkstyle` to 8.10
* Upgrade `sevntu-checkstyle` to 1.29.0