### PR TITLE
Upgrade dependencies

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -1,33 +1,25 @@
+final String publicRepo = 'https://github.com/kemitix/'
 final String mvn = "mvn --batch-mode --update-snapshots --errors"
 final dependenciesSupportJDK=9
 
 pipeline {
     agent any
     stages {
-        stage('master != SNAPSHOT') {
-            // checks that the pom version is not a snapshot when the current or target branch is master
-            when {
-                expression {
-                    (env.GIT_BRANCH == 'master' || env.CHANGE_TARGET == 'master') &&
-                            (readMavenPom(file: 'pom.xml').version).contains("SNAPSHOT")
-                }
-            }
-            steps {
-                error("Build failed because SNAPSHOT version")
-            }
-        }
         stage('Build & Test') {
             steps {
-                withMaven(maven: 'maven', jdk: 'JDK LTS') {
+                withMaven(maven: 'maven', jdk: 'JDK 1.8') {
                     sh "${mvn} clean compile checkstyle:checkstyle pmd:pmd test"
-                    //junit '**/target/surefire-reports/*.xml'
+                    // Code Coverage to Codacy
                     sh "${mvn} -pl builder jacoco:report com.gavinmogan:codacy-maven-plugin:coverage " +
                             "-DcoverageReportFile=target/site/jacoco/jacoco.xml " +
                             "-DprojectToken=`$JENKINS_HOME/codacy/token` " +
                             "-DapiToken=`$JENKINS_HOME/codacy/apitoken` " +
                             "-Dcommit=`git rev-parse HEAD`"
+                    // Code Coverage to Jenkins
                     jacoco exclusionPattern: '**/*{Test|IT|Main|Application|Immutable}.class'
+                    // PMD to Jenkins
                     pmd canComputeNew: false, defaultEncoding: '', healthy: '', pattern: '', unHealthy: ''
+                    // Checkstyle to Jenkins
                     step([$class: 'hudson.plugins.checkstyle.CheckStylePublisher',
                           pattern: '**/target/checkstyle-result.xml',
                           healthy:'20',
@@ -37,32 +29,32 @@ pipeline {
         }
         stage('Verify & Install') {
             steps {
-                withMaven(maven: 'maven', jdk: 'JDK LTS') {
+                withMaven(maven: 'maven', jdk: 'JDK 1.8') {
                     sh "${mvn} -DskipTests install"
                 }
             }
         }
-        stage('SonarQube (github only)') {
-            when { expression { env.GIT_URL.startsWith('https://github.com') } }
+        stage('SonarQube (published)') {
+            when { expression { isPublished(publicRepo) } }
             steps {
                 withSonarQubeEnv('sonarqube') {
-                    withMaven(maven: 'maven', jdk: 'JDK LTS') {
+                    withMaven(maven: 'maven', jdk: 'JDK 1.8') {
                         sh "${mvn} org.sonarsource.scanner.maven:sonar-maven-plugin:3.4.0.905:sonar"
                     }
                 }
             }
         }
-        stage('Archiving') {
-            when { expression { findFiles(glob: '**/target/*.jar').length > 0 } }
-            steps {
-                archiveArtifacts '**/target/*.jar'
+        stage('Deploy (published release branch)') {
+            when {
+                expression {
+                    (isReleaseBranch() &&
+                            isPublished(publicRepo) &&
+                            notSnapshot())
+                }
             }
-        }
-        stage('Deploy (master on github)') {
-            when { expression { (env.GIT_BRANCH == 'master' && env.GIT_URL.startsWith('https://github.com')) } }
             steps {
-                withMaven(maven: 'maven', jdk: 'JDK LTS') {
-                    sh "${mvn} deploy -pl ruleset,tile --activate-profiles release -DskipTests=true"
+                withMaven(maven: 'maven', jdk: 'JDK 1.8') {
+                    sh "${mvn} -pl ruleset,tile --activate-profiles release deploy"
                 }
             }
         }
@@ -83,4 +75,24 @@ pipeline {
             }
         }
     }
+}
+
+private boolean isReleaseBranch() {
+    return branchStartsWith('release/')
+}
+
+private boolean branchStartsWith(final String branchName) {
+    startsWith(env.GIT_BRANCH, branchName)
+}
+
+private boolean isPublished(final String repo) {
+    startsWith(env.GIT_URL, repo)
+}
+
+private static boolean startsWith(final String value, final String match) {
+    value != null && value.startsWith(match)
+}
+
+private boolean notSnapshot() {
+    return !(readMavenPom(file: 'pom.xml').version).contains("SNAPSHOT")
 }

--- a/README.md
+++ b/README.md
@@ -5,12 +5,8 @@ Provides an extensive Checkstyle ruleset for use with Checkstyle, together with 
 [![Sonatype Nexus (Releases)](https://img.shields.io/nexus/r/https/oss.sonatype.org/net.kemitix/kemitix-checkstyle-ruleset.svg?style=for-the-badge)](https://oss.sonatype.org/content/repositories/releases/net/kemitix/kemitix-checkstyle-ruleset/)
 [![Maven Central](https://img.shields.io/maven-central/v/net.kemitix/kemitix-checkstyle-ruleset.svg?style=for-the-badge)](https://search.maven.org/#search|ga|1|g%3A"net.kemitix"%20AND%20a%3A"kemitix-checkstyle-ruleset")
 
-[![SonarQube Coverage](https://img.shields.io/sonar/https/sonarcloud.io/net.kemitix%3Akemitix-checkstyle-ruleset/coverage.svg?style=for-the-badge)](https://sonarcloud.io/dashboard?id=net.kemitix%3Akemitix-checkstyle-ruleset)
-[![SonarQube Tech Debt](https://img.shields.io/sonar/https/sonarcloud.io/net.kemitix%3Akemitix-checkstyle-ruleset/tech_debt.svg?style=for-the-badge)](https://sonarcloud.io/dashboard?id=net.kemitix%3Akemitix-checkstyle-ruleset)
-
-[![Jenkins](https://img.shields.io/jenkins/s/https/jenkins.kemitix.net/job/GitLab/job/kemitix%252Fkemitix-checkstyle-ruleset.svg?style=for-the-badge)](https://jenkins.kemitix.net/job/GitLab/job/kemitix%252Fkemitix-checkstyle-ruleset/)
-[![Jenkins tests](https://img.shields.io/jenkins/t/https/jenkins.kemitix.net/job/GitLab/job/kemitix%252Fkemitix-checkstyle-ruleset.svg?style=for-the-badge)](https://jenkins.kemitix.net/job/GitLab/job/kemitix%252Fkemitix-checkstyle-ruleset/)
-[![Jenkins coverage](https://img.shields.io/jenkins/c/https/jenkins.kemitix.net/job/GitLab/job/kemitix%252Fkemitix-checkstyle-ruleset.svg?style=for-the-badge)](https://jenkins.kemitix.net/job/GitLab/job/kemitix%252Fkemitix-checkstyle-ruleset/)
+[![SonarQube Coverage](https://img.shields.io/sonar/https/sonarcloud.io/net.kemitix.checkstyle%3Akemitix-checkstyle-ruleset/coverage.svg?style=for-the-badge)](https://sonarcloud.io/dashboard?id=net.kemitix%3Akemitix-checkstyle-ruleset)
+[![SonarQube Tech Debt](https://img.shields.io/sonar/https/sonarcloud.io/net.kemitix.checkstyle%3Akemitix-checkstyle-ruleset/tech_debt.svg?style=for-the-badge)](https://sonarcloud.io/dashboard?id=net.kemitix%3Akemitix-checkstyle-ruleset)
 
 [![Codacy grade](https://img.shields.io/codacy/grade/d57096b0639d496aba9a7e43e7cf5b4c.svg?style=for-the-badge)](https://app.codacy.com/project/kemitix/kemitix-checkstyle-ruleset/dashboard)
 
@@ -43,7 +39,7 @@ The simplest way to use the ruleset is with the maven-tile:
                 <extensions>true</extensions>
                 <configuration>
                     <tiles>
-                        <tile>net.kemitix.checkstyle:tile:4.1.1</tile>
+                        <tile>net.kemitix.checkstyle:tile:RELEASE</tile>
                     </tiles>
                 </configuration>
             </plugin>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.kemitix</groupId>
         <artifactId>kemitix-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.1</version>
         <relativePath/>
     </parent>
 

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -26,7 +26,7 @@
         <sevntu.version>1.29.0</sevntu.version>
         <lombok.version>1.16.20</lombok.version>
         <spring-platform.version>Brussels-SR6</spring-platform.version>
-        <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.14.RELEASE</spring-boot.version>
         <mapstream.version>2.3.5</mapstream.version>
         <map-builder.version>1.0.0</map-builder.version>
         <mockito.version>2.19.0</mockito.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -44,9 +44,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.spring.platform</groupId>
-                <artifactId>platform-bom</artifactId>
-                <version>${spring-platform.version}</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -14,7 +14,7 @@
     <groupId>net.kemitix.checkstyle</groupId>
     <artifactId>builder</artifactId>
     <packaging>jar</packaging>
-    <version>4.1.1</version>
+    <version>DEV-SNAPSHOT</version>
 
     <properties>
         <maven.install.skip>true</maven.install.skip>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -31,7 +31,7 @@
         <map-builder.version>1.0.0</map-builder.version>
         <mockito.version>2.19.0</mockito.version>
         <assertj.version>3.9.0</assertj.version>
-        <conditional.version>0.3.0</conditional.version>
+        <conditional.version>0.4.0</conditional.version>
         <fast-classpath-scanner.version>3.1.6</fast-classpath-scanner.version>
 
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -30,7 +30,7 @@
         <mapstream.version>2.3.5</mapstream.version>
         <map-builder.version>1.0.0</map-builder.version>
         <mockito.version>2.19.0</mockito.version>
-        <assertj.version>3.9.0</assertj.version>
+        <assertj.version>3.10.0</assertj.version>
         <conditional.version>0.4.0</conditional.version>
         <fast-classpath-scanner.version>3.1.6</fast-classpath-scanner.version>
 

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -38,7 +38,7 @@
         <kemitix.checkstyle.ruleset.version>${project.version}</kemitix.checkstyle.ruleset.version>
         <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>
         <kemitix.checkstyle.ruleset.location>net/kemitix/checkstyle-${kemitix.checkstyle.ruleset.level}.xml</kemitix.checkstyle.ruleset.location>
-        <javax.annotation-api.version>1.2</javax.annotation-api.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     </properties>
 
     <dependencyManagement>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -23,7 +23,7 @@
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
 
         <checkstyle.version>8.10</checkstyle.version>
-        <sevntu.version>1.29.0</sevntu.version>
+        <sevntu.version>1.30.0</sevntu.version>
         <lombok.version>1.18.0</lombok.version>
         <spring-platform.version>Brussels-SR6</spring-platform.version>
         <spring-boot.version>1.5.14.RELEASE</spring-boot.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -32,7 +32,7 @@
         <mockito.version>2.13.0</mockito.version>
         <assertj.version>3.9.0</assertj.version>
         <conditional.version>0.3.0</conditional.version>
-        <fast-classpath-scanner.version>2.18.1</fast-classpath-scanner.version>
+        <fast-classpath-scanner.version>3.1.6</fast-classpath-scanner.version>
 
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <kemitix.checkstyle.ruleset.version>${project.version}</kemitix.checkstyle.ruleset.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -29,7 +29,7 @@
         <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
         <mapstream.version>2.3.5</mapstream.version>
         <map-builder.version>1.0.0</map-builder.version>
-        <mockito.version>2.13.0</mockito.version>
+        <mockito.version>2.19.0</mockito.version>
         <assertj.version>3.9.0</assertj.version>
         <conditional.version>0.3.0</conditional.version>
         <fast-classpath-scanner.version>3.1.6</fast-classpath-scanner.version>

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -24,7 +24,7 @@
 
         <checkstyle.version>8.10</checkstyle.version>
         <sevntu.version>1.29.0</sevntu.version>
-        <lombok.version>1.16.20</lombok.version>
+        <lombok.version>1.18.0</lombok.version>
         <spring-platform.version>Brussels-SR6</spring-platform.version>
         <spring-boot.version>1.5.14.RELEASE</spring-boot.version>
         <mapstream.version>2.3.5</mapstream.version>

--- a/builder/src/main/resources/README-template.md
+++ b/builder/src/main/resources/README-template.md
@@ -2,6 +2,14 @@
 
 Provides an extensive Checkstyle ruleset for use with Checkstyle, together with a fully configured maven-tile.
 
+[![Sonatype Nexus (Releases)](https://img.shields.io/nexus/r/https/oss.sonatype.org/net.kemitix/kemitix-checkstyle-ruleset.svg?style=for-the-badge)](https://oss.sonatype.org/content/repositories/releases/net/kemitix/kemitix-checkstyle-ruleset/)
+[![Maven Central](https://img.shields.io/maven-central/v/net.kemitix/kemitix-checkstyle-ruleset.svg?style=for-the-badge)](https://search.maven.org/#search|ga|1|g%%3A"net.kemitix"%%20AND%%20a%%3A"kemitix-checkstyle-ruleset")
+
+[![SonarQube Coverage](https://img.shields.io/sonar/https/sonarcloud.io/net.kemitix.checkstyle%%3Akemitix-checkstyle-ruleset/coverage.svg?style=for-the-badge)](https://sonarcloud.io/dashboard?id=net.kemitix%%3Akemitix-checkstyle-ruleset)
+[![SonarQube Tech Debt](https://img.shields.io/sonar/https/sonarcloud.io/net.kemitix.checkstyle%%3Akemitix-checkstyle-ruleset/tech_debt.svg?style=for-the-badge)](https://sonarcloud.io/dashboard?id=net.kemitix%%3Akemitix-checkstyle-ruleset)
+
+[![Codacy grade](https://img.shields.io/codacy/grade/d57096b0639d496aba9a7e43e7cf5b4c.svg?style=for-the-badge)](https://app.codacy.com/project/kemitix/kemitix-checkstyle-ruleset/dashboard)
+
 The ruleset includes checks from both the core Checkstyle library and from the Sevntu-Checkstyle library.
 
 * [Usage](#usage)
@@ -31,7 +39,7 @@ The simplest way to use the ruleset is with the maven-tile:
                 <extensions>true</extensions>
                 <configuration>
                     <tiles>
-                        <tile>net.kemitix.checkstyle:tile:DEV-SNAPSHOT</tile>
+                        <tile>net.kemitix.checkstyle:tile:RELEASE</tile>
                     </tiles>
                 </configuration>
             </plugin>

--- a/builder/src/main/resources/README-template.md
+++ b/builder/src/main/resources/README-template.md
@@ -31,7 +31,7 @@ The simplest way to use the ruleset is with the maven-tile:
                 <extensions>true</extensions>
                 <configuration>
                     <tiles>
-                        <tile>net.kemitix.checkstyle:tile:4.1.1</tile>
+                        <tile>net.kemitix.checkstyle:tile:DEV-SNAPSHOT</tile>
                     </tiles>
                 </configuration>
             </plugin>

--- a/ruleset/pom.xml
+++ b/ruleset/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.kemitix</groupId>
         <artifactId>kemitix-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.1</version>
         <relativePath/>
     </parent>
 

--- a/ruleset/pom.xml
+++ b/ruleset/pom.xml
@@ -22,8 +22,7 @@
 
     <properties>
         <tiles-maven-plugin.version>2.11</tiles-maven-plugin.version>
-        <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
-        <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
+        <kemitix-tiles.version>0.9.0</kemitix-tiles.version>
     </properties>
 
     <licenses>
@@ -60,14 +59,6 @@
                         <tile>net.kemitix.tiles:maven-plugins:${kemitix-tiles.version}</tile>
                         <tile>net.kemitix.tiles:enforcer:${kemitix-tiles.version}</tile>
                     </tiles>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-resources-plugin.version}</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
         </plugins>

--- a/ruleset/pom.xml
+++ b/ruleset/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>net.kemitix.checkstyle</groupId>
     <artifactId>ruleset</artifactId>
-    <version>4.1.1</version>
+    <version>DEV-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Kemitix Checkstyle Ruleset</name>

--- a/tile/pom.xml
+++ b/tile/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.kemitix.checkstyle</groupId>
     <artifactId>tile</artifactId>
-    <version>4.1.1</version>
+    <version>DEV-SNAPSHOT</version>
 
     <packaging>tile</packaging>
 

--- a/tile/pom.xml
+++ b/tile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.kemitix</groupId>
         <artifactId>kemitix-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.1.1</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tile/tile.xml
+++ b/tile/tile.xml
@@ -3,7 +3,7 @@
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <checkstyle.version>8.10</checkstyle.version>
         <sevntu.version>1.29.0</sevntu.version>
-        <kemitix.checkstyle.ruleset.version>4.1.1</kemitix.checkstyle.ruleset.version>
+        <kemitix.checkstyle.ruleset.version>DEV-SNAPSHOT</kemitix.checkstyle.ruleset.version>
         <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>
         <kemitix.checkstyle.ruleset.location>net/kemitix/checkstyle-${kemitix.checkstyle.ruleset.level}.xml</kemitix.checkstyle.ruleset.location>
     </properties>


### PR DESCRIPTION
* Upgrade `kemitix-parent` to 5.1.1
* Upgrade `kemitix-maven-tiles` to 0.9.0
* Upgrade `sevntu` to 1.30.0
* Upgrade `lombok` to 1.18.0
* Upgrade `spring-boot` to 1.5.14
* Upgrade `mockito` to 2.19.0
* Upgrade `assertj` to 3.10.0
* Upgrade `conditional` to 0.4.0
* Upgrade `fast-claspath-scanner` to 3.1.6
* Upgrade `javax-annotation-api` to 1.3.2
* Replaced Spring IO Platform dependency management with Spring Boot version
* Add badges to README
* Switch to trunk-based development