### PR TITLE
Specify dependencies for tile in pom and update missing CHANGELOG changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,19 +4,21 @@ CHANGELOG
 4.1.2
 -----
 
-* Upgrade `kemitix-parent` to 5.1.1
-* Upgrade `kemitix-maven-tiles` to 0.9.0
-* Upgrade `sevntu` to 1.30.0
-* Upgrade `lombok` to 1.18.0
-* Upgrade `spring-boot` to 1.5.14
-* Upgrade `mockito` to 2.19.0
-* Upgrade `assertj` to 3.10.0
-* Upgrade `conditional` to 0.4.0
-* Upgrade `fast-claspath-scanner` to 3.1.6
-* Upgrade `javax-annotation-api` to 1.3.2
-* Replaced Spring IO Platform dependency management with Spring Boot version
-* Add badges to README
+* Upgrade checkstyle to 8.12
+* Upgrade `sevntu` to 1.32.0
 * Switch to trunk-based development
+* Upgrade `kemitix-parent` to 5.1.1
+* [tile] Upgrade `kemitix-maven-tiles` to 0.9.0
+* [tile] Bump tiles-maven-plugin from 2.11 to 2.12
+* [builder] Replaced Spring IO Platform dependency management with Spring Boot version
+* [builder] Bump spring-boot to 2.0.4.RELEASE
+* [builder] Upgrade `lombok` to 1.18.2
+* [builder] Bump mockito-core from 2.19.0 to 2.21.0
+* [builder] Upgrade `assertj` to 3.11.0
+* [builder] Upgrade `conditional` to 0.6.0
+* [builder] Upgrade `fast-classpath-scanner` to `classgraph`
+* [builder] Upgrade `javax-annotation-api` to 1.3.2
+* Add badges to README
 
 4.1.1
 -----

--- a/tile/pom.xml
+++ b/tile/pom.xml
@@ -19,8 +19,43 @@
     <properties>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
+
+        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+        <checkstyle.version>8.12</checkstyle.version>
+        <sevntu.version>1.32.0</sevntu.version>
+
+        <kemitix.checkstyle.ruleset.version>DEV-SNAPSHOT</kemitix.checkstyle.ruleset.version>
+        <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>
+        <kemitix.checkstyle.ruleset.location>net/kemitix/checkstyle-${kemitix.checkstyle.ruleset.level}.xml</kemitix.checkstyle.ruleset.location>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <version>${maven-checkstyle-plugin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.sevntu-checkstyle</groupId>
+            <artifactId>sevntu-checkstyle-maven-plugin</artifactId>
+            <version>${sevntu.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kemitix.checkstyle</groupId>
+            <artifactId>kemitix-checkstyle-ruleset</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    
     <build>
         <plugins>
             <plugin>
@@ -29,6 +64,7 @@
                 <version>${tiles-maven-plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
+                    <filtering>true</filtering>
                     <tiles>
                         <tile>net.kemitix.tiles:maven-plugins:${kemitix-tiles.version}</tile>
                     </tiles>

--- a/tile/pom.xml
+++ b/tile/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>net.kemitix.checkstyle</groupId>
-            <artifactId>kemitix-checkstyle-ruleset</artifactId>
+            <artifactId>ruleset</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/tile/tile.xml
+++ b/tile/tile.xml
@@ -1,37 +1,29 @@
 <project>
-    <properties>
-        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <checkstyle.version>8.12</checkstyle.version>
-        <sevntu.version>1.32.0</sevntu.version>
-        <kemitix.checkstyle.ruleset.version>DEV-SNAPSHOT</kemitix.checkstyle.ruleset.version>
-        <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>
-        <kemitix.checkstyle.ruleset.location>net/kemitix/checkstyle-${kemitix.checkstyle.ruleset.level}.xml</kemitix.checkstyle.ruleset.location>
-    </properties>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven-checkstyle-plugin.version}</version>
+                <version>@maven-checkstyle-plugin.version@</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>${checkstyle.version}</version>
+                        <version>@checkstyle.version@</version>
                     </dependency>
                     <dependency>
                         <groupId>com.github.sevntu-checkstyle</groupId>
                         <artifactId>sevntu-checkstyle-maven-plugin</artifactId>
-                        <version>${sevntu.version}</version>
+                        <version>@sevntu.version@</version>
                     </dependency>
                     <dependency>
                         <groupId>net.kemitix.checkstyle</groupId>
                         <artifactId>ruleset</artifactId>
-                        <version>${kemitix.checkstyle.ruleset.version}</version>
+                        <version>@kemitix.checkstyle.ruleset.version@</version>
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <configLocation>${kemitix.checkstyle.ruleset.location}</configLocation>
+                    <configLocation>@kemitix.checkstyle.ruleset.location@</configLocation>
                     <sourceDirectories>
                         <sourceDirectory>${build.sourceDirectory}</sourceDirectory>
                     </sourceDirectories>

--- a/tile/tile.xml
+++ b/tile/tile.xml
@@ -1,8 +1,8 @@
 <project>
     <properties>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <checkstyle.version>8.10</checkstyle.version>
-        <sevntu.version>1.29.0</sevntu.version>
+        <checkstyle.version>8.12</checkstyle.version>
+        <sevntu.version>1.32.0</sevntu.version>
         <kemitix.checkstyle.ruleset.version>DEV-SNAPSHOT</kemitix.checkstyle.ruleset.version>
         <kemitix.checkstyle.ruleset.level>5-complexity</kemitix.checkstyle.ruleset.level>
         <kemitix.checkstyle.ruleset.location>net/kemitix/checkstyle-${kemitix.checkstyle.ruleset.level}.xml</kemitix.checkstyle.ruleset.location>


### PR DESCRIPTION
Previously dependencies were specified directly in the tile.xml. Unfortunately tools that don't know about tiles
don't detect this, such as mvn versions:display-property-updates or dependabot.