### PR TITLE
Replace RedundantModifier with InterfaceMemberImpliedModifier rule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,12 @@
 CHANGELOG
 =========
 
-4.2.0
+5.0.0
 -----
 
+* [BREAKING] [ruleset] Replace `RedundantModifier` with `InterfaceMemberImpliedModifier`
 * [ruleset] Add rule `LambdaParameterName`
-* Upgrade checkstyle to 8.12
+* Upgrade `checkstyle` to 8.12
 * Upgrade `sevntu` to 1.32.0
 * Switch to trunk-based development
 * Upgrade `kemitix-parent` to 5.1.1

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ The following levels implement increasingly strict rulesets:
 
 The default ruleset from the maven-tile is 5-complexity. Other levels can be selected by setting the `kemitix.checkstyle.ruleset.level` to one the values above.
 
+### Change from 4.x
+
+The `RedundantModifier` rule has been replaced by the `InterfaceMemberImpliedModifier`. This is to ensure that intefaces
+in Java 9+ are easier to comprehend with the addition of private methods. The rules governing the implied modifiers for
+members of interfaces differs from those of classes. So, to remove the need to remember the different rules, they are 
+now required to be explicitly stated.
+
+### Change from 3.x
+
+Rename the artifact `net.kemitix:kemitix-checkstyle-ruleset` as `net.kemitix.checkstyle:ruleset`.
+
+Introduction of the artifact `net.kemitix.checkstyle:tile` for use with the [tiles-maven-plugin](https://github.com/repaint-io/maven-tiles).
+
 ### Change from 2.x
 
 In 2.x, the level was specified as the goal to invoke. In 3.x, there is only the 'check' goal. The level is now specified as a configuration parameter. See the example below. The kemitix-checkstyle-maven-plugin has also been removed in favour of the maven-tile.
@@ -158,6 +171,7 @@ Rule|Level|Source|Enabled|Suppressible
 [InnerAssignment](#innerassignment)|tweaks|checkstyle|Yes|
 [InnerTypeLast](#innertypelast)|tweaks|checkstyle|Yes|
 [InterfaceIsType](#interfaceistype)|complexity|checkstyle|Yes|
+[InterfaceMemberImpliedModifier](#interfacememberimpliedmodifier)|tweaks|checkstyle|Yes|
 [InterfaceTypeParameterName](#interfacetypeparametername)|naming|checkstyle|Yes|
 [JavadocMethod](#javadocmethod)|javadoc|checkstyle|Yes|
 [JavadocPackage](#javadocpackage)|javadoc|checkstyle|Yes|
@@ -223,7 +237,7 @@ Rule|Level|Source|Enabled|Suppressible
 [ParenPad](#parenpad)|layout|checkstyle|Yes|
 [PublicReferenceToPrivateType](#publicreferencetoprivatetype)|tweaks|sevntu|Yes|
 [RedundantImport](#redundantimport)|layout|checkstyle||
-[RedundantModifier](#redundantmodifier)|tweaks|checkstyle|Yes|
+[RedundantModifier](#redundantmodifier)|tweaks|checkstyle||
 [RedundantReturn](#redundantreturn)|tweaks|sevntu|Yes|
 [Regexp](#regexp)|unspecified|checkstyle||
 [RegexpHeader](#regexpheader)|unspecified|checkstyle||
@@ -1127,6 +1141,11 @@ interface Foo {
     static final String "Foo!!";
 }
 ````
+#### [InterfaceMemberImpliedModifier](http://checkstyle.sourceforge.net/config_modifier.html#InterfaceMemberImpliedModifier)
+
+Checks that members of an interface explicitly state their modifiers. From Java 9 the implied modifiers for members
+are different depending on whether they are on a class or an interface. Explicitly stating the modifiers removes the
+need for the developer to remember the differences.
 #### [InterfaceTypeParameterName](http://checkstyle.sourceforge.net/config_naming.html#InterfaceTypeParameterName)
 
 Checks that the type parameters for an interface are a single uppercase letter.
@@ -1656,15 +1675,6 @@ doSomething( );
 doSomethingElse( 5);
 doSomethingElse(5 );
 ````
-#### [RedundantModifier](http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier)
-
-Checks for redundant modifiers. Checks for:
-
-* Interface and annotation definitions.
-* Final modifier on methods of final and anonymous classes.
-* Inner interface declarations that are declared as static.
-* Class constructors.
-* Nested enum definitions that are declared as static.
 #### [RegexpOnFilename](http://checkstyle.sourceforge.net/config_regexp.html#RegexpOnFilename)
 
 Checks for the existence of forbidden java file names.
@@ -2654,6 +2664,9 @@ Already covered by the [OneTopLevelClass](#onetoplevelclass) check.
 #### [RedundantImport](http://checkstyle.sourceforge.net/config_imports.html#RedundantImport)
 
 [UnusedImports](#unusedimports) performs all the same checks and more.
+#### [RedundantModifier](http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier)
+
+conflicts with InterfaceMemberImpliedModifier which is now prefered given changes to interfaces in Java 9
 #### [Regexp](http://checkstyle.sourceforge.net/config_regexp.html#Regexp)
 
 Generic rule; doesn't embody a 'quality' check.

--- a/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/ReadmeIndexBuilder.java
+++ b/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/ReadmeIndexBuilder.java
@@ -33,5 +33,5 @@ public interface ReadmeIndexBuilder {
      *
      * @return The rule index.
      */
-    String build();
+    public abstract String build();
 }

--- a/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/RuleReadmeLoader.java
+++ b/builder/src/main/java/net/kemitix/checkstyle/ruleset/builder/RuleReadmeLoader.java
@@ -38,5 +38,5 @@ interface RuleReadmeLoader {
      *
      * @return A Stream of the readme fragment.
      */
-    Stream<String> load(Rule rule);
+    public abstract Stream<String> load(Rule rule);
 }

--- a/builder/src/main/resources/README-template.md
+++ b/builder/src/main/resources/README-template.md
@@ -69,6 +69,19 @@ The following levels implement increasingly strict rulesets:
 
 The default ruleset from the maven-tile is 5-complexity. Other levels can be selected by setting the `kemitix.checkstyle.ruleset.level` to one the values above.
 
+### Change from 4.x
+
+The `RedundantModifier` rule has been replaced by the `InterfaceMemberImpliedModifier`. This is to ensure that intefaces
+in Java 9+ are easier to comprehend with the addition of private methods. The rules governing the implied modifiers for
+members of interfaces differs from those of classes. So, to remove the need to remember the different rules, they are 
+now required to be explicitly stated.
+
+### Change from 3.x
+
+Rename the artifact `net.kemitix:kemitix-checkstyle-ruleset` as `net.kemitix.checkstyle:ruleset`.
+
+Introduction of the artifact `net.kemitix.checkstyle:tile` for use with the [tiles-maven-plugin](https://github.com/repaint-io/maven-tiles).
+
 ### Change from 2.x
 
 In 2.x, the level was specified as the goal to invoke. In 3.x, there is only the 'check' goal. The level is now specified as a configuration parameter. See the example below. The kemitix-checkstyle-maven-plugin has also been removed in favour of the maven-tile.

--- a/builder/src/main/resources/application.yml
+++ b/builder/src/main/resources/application.yml
@@ -470,6 +470,13 @@ rules:
             fileMaximum: 250
             methodMaximum: 12
     -
+        name: LambdaParameterName
+        parent: TREEWALKER
+        level: NAMING
+        enabled: true
+        source: CHECKSTYLE
+        uri: http://checkstyle.sourceforge.net/config_naming.html#LambdaParameterName
+    -
         name: LeftCurly
         parent: TREEWALKER
         level: LAYOUT
@@ -1067,13 +1074,6 @@ rules:
         enabled: true
         source: SEVNTU
         uri: http://sevntu-checkstyle.github.io/sevntu.checkstyle/apidocs/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheck.html
-    -
-        name: LambdaParameterName
-        parent: TREEWALKER
-        level: NAMING
-        enabled: true
-        source: CHECKSTYLE
-        uri: http://checkstyle.sourceforge.net/config_naming.html#LambdaParameterName
     -
         name: LogicConditionNeedOptimization
         parent: TREEWALKER

--- a/builder/src/main/resources/application.yml
+++ b/builder/src/main/resources/application.yml
@@ -413,6 +413,13 @@ rules:
         source: CHECKSTYLE
         uri: http://checkstyle.sourceforge.net/config_design.html#InterfaceIsType
     -
+        name: InterfaceMemberImpliedModifier
+        parent: TREEWALKER
+        level: TWEAKS
+        enabled: true
+        source: CHECKSTYLE
+        uri: http://checkstyle.sourceforge.net/config_modifier.html#InterfaceMemberImpliedModifier
+    -
         name: InterfaceTypeParameterName
         parent: TREEWALKER
         level: NAMING
@@ -792,9 +799,10 @@ rules:
         name: RedundantModifier
         parent: TREEWALKER
         level: TWEAKS
-        enabled: true
+        enabled: false
         source: CHECKSTYLE
         uri: http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier
+        reason: conflicts with InterfaceMemberImpliedModifier which is now prefered given changes to interfaces in Java 9
     -
         name: RequireThis
         parent: TREEWALKER

--- a/builder/src/main/resources/rules/InterfaceMemberImpliedModifier.md
+++ b/builder/src/main/resources/rules/InterfaceMemberImpliedModifier.md
@@ -1,0 +1,4 @@
+
+Checks that members of an interface explicitly state their modifiers. From Java 9 the implied modifiers for members
+are different depending on whether they are on a class or an interface. Explicitly stating the modifiers removes the
+need for the developer to remember the differences.

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-2-naming.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-2-naming.xml
@@ -35,6 +35,7 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
         <property name="max" value="120"/>
@@ -85,7 +86,6 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscoreCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotationCheck"/>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-3-javadoc.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-3-javadoc.xml
@@ -50,6 +50,7 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
         <property name="max" value="120"/>
@@ -109,7 +110,6 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscoreCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotationCheck"/>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
@@ -77,6 +77,7 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
         <property name="max" value="120"/>
@@ -158,7 +159,6 @@
 <module name="com.github.sevntu.checkstyle.checks.coding.EitherLogOrThrowCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.LogicConditionNeedOptimizationCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.design.NoMainMethodInAbstractClassCheck"/>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-4-tweaks.xml
@@ -68,6 +68,7 @@
 </module>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck">
         <property name="allowMissingPropertyJavadoc" value="true"/>
@@ -120,7 +121,6 @@
 </module>
 <module name="com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck">
         <property name="checkMethods" value="false"/>
 </module>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
@@ -88,6 +88,7 @@
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.design.InterfaceIsTypeCheck"/>
+<module name="com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.naming.InterfaceTypeParameterNameCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck">
         <property name="allowMissingPropertyJavadoc" value="true"/>
@@ -162,7 +163,6 @@
         <property name="ignoreOverriddenMethods" value="true"/>
 </module>
 <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck">
         <property name="checkMethods" value="false"/>
 </module>

--- a/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
+++ b/ruleset/src/main/resources/net/kemitix/checkstyle-5-complexity.xml
@@ -102,6 +102,7 @@
         <property name="fileMaximum" value="250"/>
         <property name="methodMaximum" value="12"/>
 </module>
+<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck"/>
 <module name="com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck">
         <property name="max" value="120"/>
@@ -208,7 +209,6 @@
 <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethodsCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.ForbidReturnInFinallyBlockCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.design.ForbidWildcardAsReturnTypeCheck"/>
-<module name="com.puppycrawl.tools.checkstyle.checks.naming.LambdaParameterNameCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.LogicConditionNeedOptimizationCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.MapIterationInForEachLoopCheck"/>
 <module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClassesCheck"/>


### PR DESCRIPTION
This is a breaking change as the new rule is a direct contradiction to the old.
In most cases interface members will now need to be explicitly declared as
public abstract.