### PR TITLE
Bump kemitix-maven-tiles from 0.8.1 to 1.1.0

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -1,6 +1,6 @@
 final String publicRepo = 'https://github.com/kemitix/'
 final String mvn = "mvn --batch-mode --update-snapshots --errors"
-final dependenciesSupportJDK=9
+final dependenciesSupportJDK=10
 
 pipeline {
     agent any

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -20,7 +20,7 @@
         <maven.install.skip>true</maven.install.skip>
         <java.version>1.8</java.version>
         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
-        <kemitix-tiles.version>0.8.1</kemitix-tiles.version>
+        <kemitix-tiles.version>1.1.0</kemitix-tiles.version>
 
         <checkstyle.version>8.12</checkstyle.version>
         <sevntu.version>1.32.0</sevntu.version>


### PR DESCRIPTION
**kemitix-maven-tiles 1.1.0**
* Improved detection of dependencies
* Bump versions-maven-plugin from 2.5 to 2.6
* Bump digraph-dependency-maven-plugin from 0.9.0 to 0.9.1

**kemitix-maven-tiles 1.0.0**
* Bump maven-compiler-plugin from 3.7.0 to 3.8.0
* Bump jacoco-maven-plugin from 0.8.1 to 0.8.2
* Bump pitest-maven-plugin from 1.4.0 to 1.4.2
* Bump pmd from 6.5.0 to 6.6.0
* Bump tiles-maven-plugin from 2.11 to 2.12