### PR TITLE
[bug] tile depends on DEV-SNAPSHOT ruleset

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.1
 -----
 
+* [bug] tile depends on DEV-SNAPSHOT ruleset (#137)
 * Bump mockito-core from 2.22.0 to 2.23.0 (#129)
 * Bump kemitix-parent from 5.1.1 to 5.2.0 (#130)
 * [jenkins] Don't use verify profile with clean phase (#131)

--- a/set-version.sh
+++ b/set-version.sh
@@ -11,5 +11,5 @@ NEXT=$1
 echo "Updating version to $NEXT..."
 mvn versions:set -DnewVersion=$NEXT -DgenerateBackupPoms=false -DprocessAllModules
 echo "Updating README template..."
-perl -p -i -e "s,DEV-SNAPSHOT</,$NEXT</," builder/src/main/resources/README-template.md
+perl -p -i -e "s,DEV-SNAPSHOT</,$NEXT</," builder/src/main/resources/README-template.md tile/pom.xml
 echo "Done."


### PR DESCRIPTION
The `set-version.sh` script didn't update the tile `pom.xml` file.